### PR TITLE
feat: filter origins & delegates

### DIFF
--- a/src/heliaRemotePinner.ts
+++ b/src/heliaRemotePinner.ts
@@ -141,16 +141,20 @@ export class HeliaRemotePinner {
     return updatedPinStatus
   }
 
+  #getPinArg ({ cid, ...otherArgs }: Omit<Pin, 'cid'> & { cid: CID }): Pin {
+    return {
+      ...otherArgs,
+      cid: cid.toString(),
+      // @ts-expect-error - broken types: origins needs to be an array of strings
+      origins: this.getOrigins(otherArgs.origins)
+    }
+  }
+
   async addPin ({ cid, signal, ...otherArgs }: AddPinArgs): Promise<PinStatus> {
     signal?.throwIfAborted()
 
     const pinStatus = await this.remotePinningClient.pinsPost({
-      pin: {
-        ...otherArgs,
-        cid: cid.toString(),
-        // @ts-expect-error - broken types: origins needs to be an array of strings
-        origins: this.getOrigins(otherArgs.origins)
-      }
+      pin: this.#getPinArg({ cid, ...otherArgs })
     }, {
       signal
     })
@@ -162,12 +166,7 @@ export class HeliaRemotePinner {
 
     const pinStatus = await this.remotePinningClient.pinsRequestidPost({
       requestid,
-      pin: {
-        ...otherArgs,
-        cid: cid.toString(),
-        // @ts-expect-error - broken types: origins needs to be an array of strings
-        origins: this.getOrigins(otherArgs.origins)
-      }
+      pin: this.#getPinArg({ cid, ...otherArgs })
     }, {
       signal
     })

--- a/src/heliaRemotePinner.ts
+++ b/src/heliaRemotePinner.ts
@@ -65,6 +65,7 @@ export class HeliaRemotePinner {
   private readonly config: Pick<Required<HeliaRemotePinnerConfig>, 'mergeOrigins' | 'retryOptions'> & HeliaRemotePinnerConfig
   constructor (private readonly heliaInstance: Helia, private readonly remotePinningClient: RemotePinningServiceClient, config?: HeliaRemotePinnerConfig) {
     this.config = {
+      ...config,
       mergeOrigins: config?.mergeOrigins ?? false,
       retryOptions: {
         retries: 10,

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,5 +1,6 @@
 import { unixfs, type UnixFS } from '@helia/unixfs'
 import { Configuration, RemotePinningServiceClient, Status } from '@ipfs-shipyard/pinning-service-client'
+import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
 import { createHelia } from 'helia'
 import sinon, { type SinonSandbox, type SinonStub } from 'sinon'
@@ -143,7 +144,7 @@ describe('@helia/remote-pinning', function () {
       const addPinResult = await remotePinner.addPin({
         cid,
         name: 'pinned-test4',
-        origins: new Set(['http://localhost:4444'])
+        origins: [multiaddr('/ip4/127.0.0.1/tcp/4001')]
       })
       expect(addPinResult.status).to.equal(Status.Pinned)
     })


### PR DESCRIPTION
This PR adds more configuration options and no longer merges origins by default.

New configuration options:
* mergeOrigins: `boolean`
* filterOrigins: `(origins: string[]) => string[]`
* filterDelegates: `(delegates: string[]) => string[]`

New functionality:
* only merge origins if mergeOrigins option is true
* returned origins have providedOrigins appearing earlier in origins array than `helia.libp2p.getMultiaddrs()` origins.
