### PR TITLE
chore: update helia, other deps; remove unused ts-expect-error

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,26 +158,26 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "@libp2p/logger": "^3.0.2",
-    "@multiformats/multiaddr": "^12.1.7",
-    "@multiformats/multiaddr-matcher": "^1.0.1",
-    "multiformats": "^12.1.1",
-    "p-retry": "^6.0.0"
+    "@libp2p/logger": "^4.0.1",
+    "@multiformats/multiaddr": "^12.1.11",
+    "@multiformats/multiaddr-matcher": "^1.1.0",
+    "multiformats": "^12.1.3",
+    "p-retry": "^6.1.0"
   },
   "devDependencies": {
-    "@helia/interface": "^2.0.0",
-    "@helia/unixfs": "^1.4.1",
+    "@helia/interface": "^2.1.0",
+    "@helia/unixfs": "^1.4.3",
     "@ipfs-shipyard/pinning-service-client": "^1.0.3",
     "@types/express": "^4.17.17",
-    "aegir": "^40.0.12",
+    "aegir": "^41.1.14",
     "get-port": "^7.0.0",
     "mock-ipfs-pinning-service": "^0.4.2",
     "nyc": "^15.1.0",
-    "sinon": "^15.2.0"
+    "sinon": "^17.0.1"
   },
   "peerDependencies": {
     "@ipfs-shipyard/pinning-service-client": "^1.0.3",
-    "helia": "^1.3.11"
+    "helia": "^2.1.0"
   },
   "publishConfig": {
     "access": "public"

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -24,7 +24,6 @@ describe('@helia/remote-pinning', function () {
 
   beforeEach(async function () {
     sinonSandbox = sinon.createSandbox()
-    // @ts-expect-error - broken types
     helia = await createHelia()
     heliaFs = unixfs(helia)
     dialStub = sinonSandbox.stub(helia.libp2p, 'dial')


### PR DESCRIPTION
## Summary

Update `helia` and some related deps to the latest, and remove a test's`ts-expect-error` since it was no longer needed.

## Details

The pinning tests pass. However, the rest fail. This happens with the latest code on `main`, prior to these changes, so this PR isn't the root cause for that.

```
  @helia/remote-pinning
    addPin
      ✔ Returns pinned status when pinning succeeds (66ms)
      ✔ Returns failed status when pinning fails (47ms)
      ✔ will await a queued pin until a signal times out (112ms)
      ✔ Stops listening when signal is aborted (103ms)
      ✔ Will not pin if provided an already aborted signal
      ✔ Does not return FailedToConnectToDelegates when unable to connect to a single delegate (40ms)
      ✔ can receive additional remote origins (40ms)
    replacePin
      ✔ will replace a previously added pin (74ms)
      ✔ Will not replace the pin if provided an already aborted signal (45ms)


  9 passing (6s)

test browser
aegir before
server stopped listening on port 61555
server listening on port 61610
✘ TypeError: os.availableParallelism is not a function
    at cpy (file:///Users/dtb/Desktop/helia-remote-pinning/node_modules/cpy/index.js:139:20)
    at Runner.setupContext (file:///Users/dtb/Desktop/helia-remote-pinning/node_modules/playwright-test/src/runner.js:83:11)
    at Runner.run (file:///Users/dtb/Desktop/helia-remote-pinning/node_modules/playwright-test/src/runner.js:312:34)
Command failed with exit code 1: /Users/dtb/Desktop/helia-remote-pinning/node_modules/.bin/pw-test test/**/*.spec.{js,cjs,mjs} test/browser.{js,cjs,mjs} dist/test/**/*.spec.{js,cjs,mjs} dist/test/browser.{
```