### PR TITLE
chore: generate valid auth token

### DIFF
--- a/packages/interop/test/compliance.spec.ts
+++ b/packages/interop/test/compliance.spec.ts
@@ -16,6 +16,16 @@ describe('pinning service compliance', function () {
   beforeEach(async () => {
     authtoken = nanoid()
 
+    // generate a token that can be passed as a CLI arg without tripping up the
+    // arg parser
+    while (true) {
+      if (authtoken.startsWith('-')) {
+        authtoken = nanoid()
+      } else {
+        break
+      }
+    }
+
     helia = await createHelia()
     server = await createPinningServiceAPIServer(helia, {
       validateAccessToken: (token) => {


### PR DESCRIPTION
`nanoid` can generate a token that starts with `-` which the CLI arg parser treats as a flag, so regenerate until a parsable token is generated.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
